### PR TITLE
Update output to match new ecr output

### DIFF
--- a/.github/workflows/release_or_label.yml
+++ b/.github/workflows/release_or_label.yml
@@ -1,0 +1,19 @@
+﻿name: Release or Label Workflow
+run-name: ${{ github.event_name == 'push' && 'Create Release Version' || 'Require PR Labels' }}
+
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+  push:
+    branches:
+      - main
+
+jobs:
+  release_or_label:
+    name: ${{ github.event_name == 'push' && 'release_on_push' || 'require_label' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: 7Factor/pr-semver-release-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          update_major_minor_tags: true

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "5.98.0"
+  hashes = [
+    "h1:/RMObGCrfJlVoQCf9h88hFkSyLafDXnw6r0yi4gpO80=",
+    "zh:23377bd90204b6203b904f48f53edcae3294eb072d8fc18a4531c0cde531a3a1",
+    "zh:2e55a6ea14cc43b08cf82d43063e96c5c2f58ee953c2628523d0ee918fe3b609",
+    "zh:4885a817c16fdaaeddc5031edc9594c1f300db0e5b23be7cd76a473e7dcc7b4f",
+    "zh:6ca7177ad4e5c9d93dee4be1ac0792b37107df04657fddfe0c976f36abdd18b5",
+    "zh:78bf8eb0a67bae5dede09666676c7a38c9fb8d1b80a90ba06cf36ae268257d6f",
+    "zh:874b5a99457a3f88e2915df8773120846b63d820868a8f43082193f3dc84adcb",
+    "zh:95e1e4cf587cde4537ac9dfee9e94270652c812ab31fce3a431778c053abf354",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a75145b58b241d64570803e6565c72467cd664633df32678755b51871f553e50",
+    "zh:aa31b13d0b0e8432940d6892a48b6268721fa54a02ed62ee42745186ee32f58d",
+    "zh:ae4565770f76672ce8e96528cbb66afdade1f91383123c079c7fdeafcb3d2877",
+    "zh:b99f042c45bf6aa69dd73f3f6d9cbe0b495b30442c526e0b3810089c059ba724",
+    "zh:bbb38e86d926ef101cefafe8fe090c57f2b1356eac9fc5ec81af310c50375897",
+    "zh:d03c89988ba4a0bd3cfc8659f951183ae7027aa8018a7ca1e53a300944af59cb",
+    "zh:d179ef28843fe663fc63169291a211898199009f0d3f63f0a6f65349e77727ec",
+  ]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,4 +1,4 @@
 output "ecr_repository_urls" {
-  value       = values(aws_ecr_repository.repos)[*].repository_url
+  value       = values(aws_ecr_repository.repos)[*].repository_uri
   description = "A list of urls of the repositories that were created."
 }


### PR DESCRIPTION
The value seems to have changed for the output of the `repository_url`

![image](https://github.com/user-attachments/assets/7c750caa-d054-46c5-9c1a-2103cc382d89)

https://github.com/hashicorp/terraform-provider-aws/issues/18321